### PR TITLE
Use `trigger_error` instead of `error_log`

### DIFF
--- a/src/GenericObject.php
+++ b/src/GenericObject.php
@@ -31,7 +31,7 @@ class GenericObject {
                 $daoClassName = get_called_class() . "DAO";
                 self::$dao[get_called_class()] = new $daoClassName(get_called_class());
             } else {
-                error_log("DAO for class " . get_called_class() . " requested, but not found");
+                trigger_error("DAO for class " . get_called_class() . " requested, but not found", E_USER_WARNING);
             }
         }
 
@@ -51,7 +51,7 @@ class GenericObject {
             $propertyName = $property->getName();
 
             if(!array_key_exists($propertyName, $data)) {
-                error_log("Property \"{$propertyName}\" does not exist in data array");
+                trigger_error("Property \"{$propertyName}\" does not exist in data array", E_USER_WARNING);
                 continue;
             }
 

--- a/src/GenericObjectDAO.php
+++ b/src/GenericObjectDAO.php
@@ -46,7 +46,7 @@ class GenericObjectDAO {
 
             return true;
         } else {
-            error_log("Trying to save " . get_class($object) . ", but table does not exist");
+            trigger_error("Trying to save " . get_class($object) . ", but table does not exist", E_USER_WARNING);
         }
 
         return false;
@@ -72,10 +72,10 @@ class GenericObjectDAO {
 
                 return true;
             } else {
-                error_log("Trying to delete " . get_class($object) . ", but id is null");
+                trigger_error("Trying to delete " . get_class($object) . ", but id is null", E_USER_WARNING);
             }
         } else {
-            error_log("Trying to delete " . get_class($object) . ", but table does not exist");
+            trigger_error("Trying to delete " . get_class($object) . ", but table does not exist", E_USER_WARNING);
         }
 
         return false;
@@ -129,7 +129,7 @@ class GenericObjectDAO {
 
             return $objects;
         } else {
-            error_log("Trying to get " . $this->CLASS_INSTANCE . ", but table does not exist");
+            trigger_error("Trying to get " . $this->CLASS_INSTANCE . ", but table does not exist", E_USER_WARNING);
         }
 
         return [];


### PR DESCRIPTION
Using `trigger_error` instead of `error_log` allows error handling with the custom logger instead of writing the error in the PHP logfile